### PR TITLE
Fix C++11 compatibility

### DIFF
--- a/include/plugins/binarization.hpp
+++ b/include/plugins/binarization.hpp
@@ -950,7 +950,7 @@ Image* brink_threshold(const T& image)
   unsigned long vecSum = 0;     // sum of histogram
   double invHistSum;            // inverse of histogram sum
   int Topt = 0;                 // threshold value
-  double locMin = numeric_limits<double>::max(); // local minimum
+  double locMin = std::numeric_limits<double>::max(); // local minimum
   int isMinInit = 0;            // flat for minimum initialization
 
   FloatVector *histoFV;

--- a/include/plugins/misc_filters.hpp
+++ b/include/plugins/misc_filters.hpp
@@ -29,8 +29,6 @@
 #include "convolution.hpp"
 #include <math.h>
 
-using namespace std;
-
 namespace Gamera {
 
   //---------------------------
@@ -408,7 +406,7 @@ namespace Gamera {
     FloatImageView *res= new FloatImageView(*res_data);
 
 	GetPixel4Border<FloatImageView> gp(src, border_treatment, k);
-    vector<FloatPixel> window(k*k);
+    std::vector<FloatPixel> window(k*k);
     
     int radius = (k-1)/2;
     for(y = 0 ; (size_t)y < src.nrows() ; y++) {

--- a/include/rle_data.hpp
+++ b/include/rle_data.hpp
@@ -147,6 +147,7 @@ namespace Gamera {
     */
     typedef unsigned char runsize_t;
 
+#if __cplusplus < 201103
     /*
       These are convenience functions to make dealing
       with the list iterators a little easier.
@@ -160,6 +161,7 @@ namespace Gamera {
     T prev(T i) {
       return --i;
     }
+#endif
   
     /*
       This class holds the actual run as a value, beginning position, and


### PR DESCRIPTION
These patches fix build failures in C++11 (or C++14) mode.
Note that C++14 is now the default mode in GCC 6.