### PR TITLE
Fix typos in documentation

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -294,7 +294,7 @@ to your search PATH, or install the scripts to ``/usr/bin`` with::
   sudo pythonw setup.py install_scripts -d /usr/bin
 
 .. note::
-  In its default configuraton, the Python distutils on MacOS X
+  In its default configuration, the Python distutils on MacOS X
   build fat binaries. You can speedup the compilation time
   by a factor two by removing the unnecessary architecture from
   your distutils build settings.
@@ -357,7 +357,7 @@ Prerequisites
 Standard Build and Install
 ``````````````````````````
 
-Download and install the unoffical wxPython-Gtk-X11 distribution from
+Download and install the unofficial wxPython-Gtk-X11 distribution from
 the Gamera Files section on SourceForge.
 
   Alternatively, you can install fink and then build the package

--- a/doc/src/classify.txt
+++ b/doc/src/classify.txt
@@ -243,7 +243,7 @@ Each classifier has the following member variables:
     must be converted to a list with ``list(classifier.get_glyphs())``.
 
   ``confidence_types``
-    List of confidence types tht are to be computed during 
+    List of confidence types that are to be computed during 
     classification. The confidence types must be from the
     predefined `confidence constants`__.
     
@@ -261,7 +261,7 @@ the constructor of ``NonInteractiveClassifier`` is described here.
 Classification
 ``````````````
 
-The following methods deal with classifying glyphs on a individual level.
+The following methods deal with classifying glyphs on an individual level.
 
 .. docstring:: gamera.classify NonInteractiveClassifier classify_glyph_automatic classify_list_automatic classify_and_update_list_automatic guess_glyph_automatic
 .. docstring:: gamera.knn _kNNBase classify_with_images

--- a/doc/src/directory_heirarchy.txt
+++ b/doc/src/directory_heirarchy.txt
@@ -63,7 +63,7 @@ The Gamera source tree looks something like this:
 |                     | graph/        | A graph library.  API should be considered     |
 |                     |               | unstable.                                      |
 |                     +---------------+------------------------------------------------+
-|                     | libtiff/      | libtiff_: A library for reading/writting Tagged|
+|                     | libtiff/      | libtiff_: A library for reading/writing Tagged |
 |                     |               | Image Format Files (otherwise known as *Tons of|
 |                     |               | Incompatible File Formats*).  Included for     |
 |                     |               | compiling convenience on MS-Windows and Mac    |

--- a/doc/src/ga_optimization.txt
+++ b/doc/src/ga_optimization.txt
@@ -73,15 +73,15 @@ stop the optimization process. After the optimizer has finished, the results
 can be saved using **File -> Save to XML** or **File -> Save to XML as**.
 
 Classifier specific settings are configurable through the **Classifier** menu.
-With **Classifier -> Copy classifier** it is possible to create an
+With **Classifier -> Copy classifier** it is possible to create a
 copy from the loaded classifier for the optimization process. The menu entry
 **Classifier -> Classifier to Gamera-GUI** allows the usage of the
 optimized classifier in the Gamera main window. Through **Classifier ->
-Load settings from XML** an settings xml file will be loaded and applied.
+Load settings from XML** a settings xml file will be loaded and applied.
 
 The used feature set can be modified with **Classifier -> Change feature set**.
 With the menu entries **Classifier -> Reset selections** and
-**Classifier -> Reset weights** it is possible to discard already choosen
+**Classifier -> Reset weights** it is possible to discard already chosen
 optimizations.
 
 .. __: gamera_xml.html
@@ -331,7 +331,7 @@ References
 ----------
 
 .. [Holland1975] Holland, J. H. (1975). *Adaptation in natural and
-   artifical systems.*  University of Michigan Press, Ann Arbor.
+   artificial systems.*  University of Michigan Press, Ann Arbor.
 
 .. [EOdev] Keijzer, M., Merelo, J. J., Romero, G., & Schoenauer, M. (2002).
    `Evolving objects: A general purpose evolutionary computation library`__.

--- a/doc/src/graph.txt
+++ b/doc/src/graph.txt
@@ -98,7 +98,7 @@ as a starting point:
 
 Note that the search algorithms, like many other things in the Gamera
 graph library, return lazy iterators, so the results are determined on
-demand.  Importantly, this means you can not get the length of the
+demand.  Importantly, this means you cannot get the length of the
 result until it has been entirely evaluated.
 
 .. code:: Python

--- a/doc/src/gui.txt
+++ b/doc/src/gui.txt
@@ -105,7 +105,7 @@ perform operations on an image.
 
   .. image:: images/right_click_menu.png
 
-At the top of the menu, the pixel type is displayeimage_api.htmld.
+At the top of the menu, the pixel type is displayed.
 
 The next two items are for creating new references and copies of the
 image.  You will be prompted for a variable name for the result.
@@ -252,7 +252,7 @@ The image display toolbar has the following buttons:
 .. note:: 
   On Linux and OS-X, the Print command works by printing to a
   PostScript file and then sends the result to ``lpr``.  Because of
-  this, it can not properly detect the resolution of the printer.
+  this, it cannot properly detect the resolution of the printer.
   Therefore, a reasonable default of 720dpi is used.  Future versions
   of wxPython may handle this better.
 
@@ -452,7 +452,7 @@ display.
 Symbol table
 ''''''''''''
 
-The symbol table is a heirarchical tree of symbol names that are
+The symbol table is a hierarchical tree of symbol names that are
 currently in use.  It is preloaded with `special class names`_.
 
 Symbols can be trained by typing the class name in the text box at

--- a/doc/src/image_api.txt
+++ b/doc/src/image_api.txt
@@ -270,7 +270,7 @@ the underlying data.  Therefore:
 
 .. code:: CPP
 
-   // Create data with an size of (64, 64) and an offset of (32, 32);
+   // Create data with a size of (64, 64) and an offset of (32, 32);
    OneBitImageData image_data(Size(64, 64), Point(32, 32));
    // This is a view over all of the data
    OneBitImageView image_view(image_data, Point(32, 32), Size(64, 64));
@@ -407,7 +407,7 @@ arrays:
 This interface is provided as a convenience to support the large body
 of legacy code written in this style.  Note that ``[row][col]`` is the
 reverse of get and set's ``Point(x, y)``.  Keep in mind, it is not really
-a 2-diminsional array underneath -- this view is "faked."
+a 2-dimensional array underneath -- this view is "faked."
 
 An example using the C-style 2-dimensional array interface:
 
@@ -448,7 +448,7 @@ Gamera has three kinds of iterators:
 The first two kinds of iterators follow the conventions of the C++ STL
 enough that they can be used with STL algorithms.  All iterators are
 available in ``const`` and non-``const`` versions.  ``const``
-iterators can not change the underlying data.  If you have an image
+iterators cannot change the underlying data.  If you have an image
 passed into your function as a ``const ImageView<T> &``, you will not
 be able to change the pixels in the image, and thus will only be able
 to get ``const`` iterators from it.
@@ -523,7 +523,7 @@ Sometimes it is necessary to have nested loops, one for rows and one
 for columns.
 
 The following is an example using row iterators (``ImageView<T>::row_iterators``) and
-column interators (``ImageView<T>::col_iterators``):
+column iterators (``ImageView<T>::col_iterators``):
 
 .. code:: CPP
 
@@ -549,7 +549,7 @@ column interators (``ImageView<T>::col_iterators``):
   }
 
 The fun thing about row and column iterators is that they are
-interchangable.  If you wish to iterate through the image in column
+interchangeable.  If you wish to iterate through the image in column
 major order instead, you could write:
 
 .. code:: CPP
@@ -814,7 +814,7 @@ pixels is not fixed.):
     }
   };
 
-  // This is specialied for FLOAT pixels
+  // This is specialized for FLOAT pixels
   template<>
   struct invert_specialized<FloatPixel> {
     template<class T>

--- a/doc/src/image_types.txt
+++ b/doc/src/image_types.txt
@@ -48,7 +48,7 @@ The pixels in an image can be one of the following types:
         Double-precision floating point greyscale.  This is useful for images
         that need a really wide dynamic range.
 
-   .. warning:: Unfortunately, at this time ``FLOAT`` images can not be saved
+   .. warning:: Unfortunately, at this time ``FLOAT`` images cannot be saved
       or loaded.
 
    .. note:: When ``FLOAT`` images are displayed in the GUI, the
@@ -225,7 +225,7 @@ Multi-Label Connected Components
 
 MultiLabelCCs (``MlCc`` on the python side, and ``MultiLabelCC`` on the 
 C++ side) basically work in the same way as 'regular'
-Connected Components. The difference between those two is the abillity
+Connected Components. The difference between those two is the ability
 of MlCcs to have multiple labels. Each label has an associated ``Rect``
 representing its bounding box; the bounding box of the entire MlCc is
 the closure of all label bounding boxes.

--- a/doc/src/index.txt
+++ b/doc/src/index.txt
@@ -96,7 +96,7 @@ Reference
 
 .. __: plugins.html
 
-- `Directory heirarchy`__: Where the files are.
+- `Directory hierarchy`__: Where the files are.
 
 .. __: directory_heirarchy.html
 

--- a/doc/src/install.txt
+++ b/doc/src/install.txt
@@ -56,8 +56,8 @@ on your system for some reason, you can switch it off with::
   python setup.py build --openmp=no
 
 
-Installing without root priviledges
------------------------------------
+Installing without root privileges
+----------------------------------
 
 .. _without_root:
 
@@ -76,7 +76,7 @@ instructions (without using sudo)::
 Alternatively, you can set up a local installation by hand.
 
 Make a local python module directory somewhere that you have write
-priviledges (such as your home directory)::
+privileges (such as your home directory)::
 
   mkdir ~/python
 
@@ -157,7 +157,7 @@ To build Gamera, open a terminal and type::
 
   python setup.py build
 
-and then to install (you'll need to have admin priviledges)::
+and then to install (you'll need to have admin privileges)::
 
   sudo pythonw setup.py install
 
@@ -180,7 +180,7 @@ to your search PATH, or install the scripts to ``/usr/bin`` with::
   sudo pythonw setup.py install_scripts -d /usr/bin
 
 .. note::
-  In its default configuraton, the Python distutils on MacOS X
+  In its default configuration, the Python distutils on MacOS X
   build fat binaries. You can speedup the compilation time
   by a factor two by removing the unnecessary architecture from
   your distutils build settings.
@@ -194,11 +194,11 @@ to your search PATH, or install the scripts to ``/usr/bin`` with::
   ``/System/Library/Frameworks/Python.framework/Versions/2.5/lib/python2.5/distutils/sysconfig.py``
 
 
-Installing without root priviledges
-```````````````````````````````````
+Installing without root privileges
+``````````````````````````````````
 
 The instructions for `installing without root (administrator)
-priviledges`__ can also be used on Mac OS-X.
+privileges`__ can also be used on Mac OS-X.
 
 __ without_root_
 
@@ -243,7 +243,7 @@ Prerequisites
 Standard Build and Install
 ``````````````````````````
 
-Download and install the unoffical wxPython-Gtk-X11 distribution from
+Download and install the unofficial wxPython-Gtk-X11 distribution from
 the Gamera Files section on SourceForge.
 
   Alternatively, you can install fink and then build the package
@@ -254,11 +254,11 @@ the Gamera Files section on SourceForge.
 
 Gamera is built using the Python-standard Distutils system.
 
-To build Gamera, open a X11 terminal and type::
+To build Gamera, open an X11 terminal and type::
 
   python setup.py build
 
-and then to install (you'll need to have admin priviledges)::
+and then to install (you'll need to have admin privileges)::
 
   sudo python setup.py install
 
@@ -271,11 +271,11 @@ The scripts can be installed by::
   default installed to
   ``/System/Library/Frameworks/Python.framework/Versions/2.3/bin``.
 
-Installing without root priviledges
-```````````````````````````````````
+Installing without root privileges
+``````````````````````````````````
 
 The instructions for `installing without root (administrator)
-priviledges`__ can also be used on Mac OS-X.
+privileges`__ can also be used on Mac OS-X.
 
 __ without_root_
 
@@ -372,7 +372,7 @@ terminal to an unreadable combination)::
     cd \path\to\gamera-sources
     \path\to\python.exe setup.py bdist_wininst
 
-The installer will be built in the subdirectory ``dist`` and can be startet
+The installer will be built in the subdirectory ``dist`` and can be started
 by double click in the explorer. Note that the installer might display an error
 message at the end, depending on the Python distutils version shipped with
 your Python installation. This message can simply be ignored.

--- a/doc/src/kdtree.txt
+++ b/doc/src/kdtree.txt
@@ -268,7 +268,7 @@ a callable class (aka *functor*, i.e. a class with the call operator
    };
 
 The call of the class only takes a single argument, the ``KdNode``, and
-returns true when this node is an admissable search result. If this
+returns true when this node is an admissible search result. If this
 criterion depends on some information from the actual search point (like
 its *x*-component in the exampel above), this information must be passed to
 the class constructor and stored within the class.

--- a/doc/src/matplotlib_support.txt
+++ b/doc/src/matplotlib_support.txt
@@ -18,7 +18,7 @@ matplotlib_ documentation.
 
 The connection between Gamera and matplotlib is intentionally minimal,
 so that it is easy to take advantage of all of matplotlib's
-functionality and to make it less dependant on any one specific
+functionality and to make it less dependent on any one specific
 version of matplotlib.  If you feel that particular graphs of
 particular kinds of data in Gamera should be made more convenient,
 please contact that Gamera authors.

--- a/doc/src/migration_guide.txt
+++ b/doc/src/migration_guide.txt
@@ -160,7 +160,7 @@ Python code
 -----------
 
 Finding the deprecated calls in Python code is somewhat more
-difficult, since the exact function calls being made can not be
+difficult, since the exact function calls being made cannot be
 determined until runtime.
 
 When a deprecated function call is made, a deprecation warning is

--- a/doc/src/overriding_knn_features.txt
+++ b/doc/src/overriding_knn_features.txt
@@ -72,7 +72,7 @@ the length of the feature vectors is calculated from that.
 '''''''''''''''''''''
 
 The ``generate_features`` function is where the feature generation
-actually happens and is called everytime the classifier needs a
+actually happens and is called every time the classifier needs a
 feature vector for a particular glyph.
 
 The feature vector itself must be stored in the member ``features`` of

--- a/doc/src/plugins_custom_types.txt
+++ b/doc/src/plugins_custom_types.txt
@@ -106,7 +106,7 @@ A fundamental problem with the conversion from PyObjects is that you
 can never be sure what actually is in the ``PyObject*``. For instance,
 when you expect a list and apply ``PyList_GetItem``, you cannot be sure
 that the ``PyObject*`` actually is a list. Nor can you safely assume that
-the list entries are of the data type you belive them to be. It is thus
+the list entries are of the data type you believe them to be. It is thus
 generally a good idea to check data types with ``PyList_Check`` and 
 ``PyObject_TypeCheck``, and to throw an exception when the wrong data
 type enters your function, e.g.

--- a/doc/src/script.txt
+++ b/doc/src/script.txt
@@ -184,7 +184,7 @@ in the previous section:
 
 - The classifier may not be as accurate as possible
 
-- Loading the XML file everytime the script starts up can be time
+- Loading the XML file every time the script starts up can be time
   consuming.
 
 If one is willing to give up the ability to add more elements to the
@@ -276,7 +276,7 @@ is directly equivalent to the following command line::
 
 Note that the name of the command line argument is changed to be a
 valid Python identifier name when used with the ``.set`` method: the
-hypens (``-``) have been replaced by underscores (``_``).  This is the
+hyphens (``-``) have been replaced by underscores (``_``).  This is the
 standard behavior of ``optparse``, the command line parsing module
 that Gamera uses.
 
@@ -284,7 +284,7 @@ Where to go from here
 ---------------------
 
 Obviously, there's a lot more to Gamera that isn't covered in this
-chapter.  Where you go from here is largely dependant on the
+chapter.  Where you go from here is largely dependent on the
 particular document domain.  Most of the work in many Gamera
 applications involves analysing the positional information, symbolic
 classification and features of the connected components to recognize

--- a/doc/src/writing_plugins.txt
+++ b/doc/src/writing_plugins.txt
@@ -8,7 +8,7 @@ Introduction
 The functionality of Gamera can be extended by writing plugins in
 either C++ or Python.  A plugin is simply a set of methods (which are
 automagically added to the ``Image`` class) or free-standing
-functions.  Plugins are technially just Python modules, but with more
+functions.  Plugins are technically just Python modules, but with more
 information that allows for easier wrapping and compilation of C++
 methods and to support all kinds of automatic things in the graphical
 user interface.
@@ -158,7 +158,7 @@ from the ``gamera.plugin module``):
 
 You can also optionally define ``return_type``.  This specifier is
 used to generate a variable name for the result in the GUI, and so the
-C++ wrapping machanism knows how to return the result to Python.  If
+C++ wrapping mechanism knows how to return the result to Python.  If
 you don't specify a return type, Gamera assumes there is no return
 result:
 
@@ -772,7 +772,7 @@ pointer to a floating point buffer.  Note that the return type is ``void``.
 and is not important for this illustration.)  Note how the result of the
 function is copied directly into the buffer.  
 
-.. note:: It is extrememly important not to write more values to the
+.. note:: It is extremely important not to write more values to the
   buffer than is defined in the metadata ``return_value``.  Doing so
   could cause Python/Gamera to behave erratically or segfault.
 

--- a/doc/src/writing_toolkits.txt
+++ b/doc/src/writing_toolkits.txt
@@ -12,7 +12,7 @@ applications that process images and return symbolic
 results (eg. an OCR package), or simply a library of utility
 functions (eg. for color image processing).
 
-A toolkit is based on Python's generic package and module heirarchy,
+A toolkit is based on Python's generic package and module hierarchy,
 which is described in the Modules chapter of the `Python tutorial`__.
 
 .. __: http://www.python.org/doc/tut/
@@ -34,11 +34,11 @@ documentation is a good resource for how to do that.
 Creating a toolkit
 ------------------
 
-The directory heirarchy
+The directory hierarchy
 ```````````````````````
 
 Toolkits require a number of different files in a directory
-heirarchy.  Here we assume the toolkit is called ``my_toolkit``.
+hierarchy.  Here we assume the toolkit is called ``my_toolkit``.
 
    +----------+----------------------------------------------------------------+
    | ./       | Basic information files for building the toolkit               |
@@ -115,7 +115,7 @@ documentation is the best resource for how to do that.
 MANIFEST.in
 '''''''''''
 
-If you need to include more data files to your toolkit distrubution,
+If you need to include more data files to your toolkit distribution,
 you will need to edit this file.  The format is described in the
 distutils documentation.
 
@@ -257,7 +257,7 @@ at least two arguments:
    *object*
       The Python object to document.
 
-Additionally, any number of names may be added to the arugment list
+Additionally, any number of names may be added to the argument list
 which will be looked up in *object* and documented.
 
 For example, to document the ``__init__`` and ``display`` methods on

--- a/gamera/classify.py
+++ b/gamera/classify.py
@@ -565,7 +565,7 @@ Removes all training data from the classifier.
       """**load_settings** (FileOpen *filename*)
 
 Loads classifier-specific settings from the given filename.  The
-format of this file is entirely dependant on the concrete classifier
+format of this file is entirely dependent on the concrete classifier
 type."""
       _Classifier.load_settings(self, filename)
       self.instantiate_from_images(self.database, self.normalize)

--- a/gamera/plugins/binarization.py
+++ b/gamera/plugins/binarization.py
@@ -347,7 +347,7 @@ class shading_subtraction(PluginFunction):
     """
     Thresholds an image after subtracting a -possibly shaded- background.
 
-    First the backgrund image is extracted with a maximum filter with a
+    First the background image is extracted with a maximum filter with a
     *k\*k* window, and this image is subtracted from the original image.
     On the difference image, a threshold is applied, and the inverted
     image thereof is the binarization result.

--- a/gamera/plugins/contour.py
+++ b/gamera/plugins/contour.py
@@ -75,7 +75,7 @@ class contour_samplepoints(PluginFunction):
   
   *percentage*:
     return percentage of contour points. The points are selected approximately
-    equidistant on the countour.
+    equidistant on the contour.
 
   *contour*:
     when 0 (\"outer_projection\"), the points returned by *contour_left* etc.

--- a/gamera/plugins/deformation.py
+++ b/gamera/plugins/deformation.py
@@ -119,7 +119,7 @@ the following meaning:
     `b0*exp(-b*d^2) + eta`, where d is the distance to the closest
     foreground pixel
 
-  - eventuall a morphological closing operation is performed with a disk
+  - eventually a morphological closing operation is performed with a disk
     of diameter *k*. If you want to skip this step set *k=0*; in that
     case you should do your own smoothing afterwards.
 

--- a/gamera/plugins/draw.py
+++ b/gamera/plugins/draw.py
@@ -511,7 +511,7 @@ class highlight(PluginFunction):
     A one-bit connected component from the image
 
   *color*
-    An color value (RGBPixel, 0-255, or [0|1], depending on the image
+    A color value (RGBPixel, 0-255, or [0|1], depending on the image
     type) used to color the *cc*.
   """
   self_type = ImageType([RGB,GREYSCALE,ONEBIT])

--- a/gamera/plugins/features.py
+++ b/gamera/plugins/features.py
@@ -230,7 +230,7 @@ class volume16regions(Feature):
 
 class volume64regions(Feature):
     """
-    Divides the image into a 8 x 8 grid of 64 regions and calculates
+    Divides the image into an 8 x 8 grid of 64 regions and calculates
     the volume within each. This feature is also known as \"zoning\" method.
 
     +---------------------------+

--- a/gamera/plugins/geometry.py
+++ b/gamera/plugins/geometry.py
@@ -47,7 +47,7 @@ class voronoi_from_labeled_image(PluginFunction):
   Springer, 1995).
 
   The example shown below is the image *voronoi_cells* as created with
-  the the following code:
+  the following code:
 
   .. code:: Python
 
@@ -96,7 +96,7 @@ class voronoi_from_points(PluginFunction):
 .. _`voronoi_from_labeled_image`: #voronoi-from-labeled-image
 
   The example shown below is the image *voronoi_edges* as created with
-  the the following code:
+  the following code:
 
   .. code:: Python
 

--- a/gamera/plugins/image_utilities.py
+++ b/gamera/plugins/image_utilities.py
@@ -371,7 +371,7 @@ greyscale image belonging to a Cc, as in the following example:
       (pmin, vmin, pmax, vmax) = grey.min_max_location(ccs[0])
 
 The return value is a tuple of the form *(pmin, vmin, pmax, vmax)* where
-*pmin* and *pmax* are the point of the minimum and maximimum, respectively,
+*pmin* and *pmax* are the point of the minimum and maximum, respectively,
 and *vmin* and *vmax* the corresponding pixel values.
 """
     category="Analysis"

--- a/gamera/plugins/listutilities.py
+++ b/gamera/plugins/listutilities.py
@@ -122,7 +122,7 @@ Arguments:
      Sample values from which the density is to be estimated.
 
   *x*
-     For each value in *x*, the desity at this position is returned
+     For each value in *x*, the density at this position is returned
      in the returned float vector.
 
   *bw*
@@ -132,7 +132,7 @@ Arguments:
 
   *kernel*
      The kernel function that weights the values (0 = rectangular, 
-     1 = triangular, 2 = gausian). A Gaussian kernel produces the smoothest
+     1 = triangular, 2 = Gaussian). A Gaussian kernel produces the smoothest
      result, but is slightly slower than the other two.
 
      Note that the kernels are normalized to variance one, which means that

--- a/gamera/plugins/pagesegmentation.py
+++ b/gamera/plugins/pagesegmentation.py
@@ -56,7 +56,7 @@ class projection_cutting(PluginFunction):
       width between adjacent text lines.
 
     *noise*:
-      maximum projection value still consideread as belonging to a
+      maximum projection value still considered as belonging to a
       'gap'.
 
     *gap_treatment*:
@@ -387,11 +387,11 @@ class sub_cc_analysis(PluginFunction):
     Further subsegments the result of a page segmentation algorithm into
     groups of actual connected components.
 
-    The result of a page segmenattion plugin is a list of 'CCs' where
+    The result of a page segmentation plugin is a list of 'CCs' where
     each 'CC' does not represent a 'connected component', but a page
     segment (typically a line of text). In a practical OCR application
     you will however need the actual connected components (which
-    should roughly corresond to the glyphs) in groups of lines. That
+    should roughly correspond to the glyphs) in groups of lines. That
     is what this plugin is meant for.
 
     The input image must be an image that has been processed with a
@@ -440,7 +440,7 @@ class textline_reading_order(PluginFunction):
     by T.M. Breuel (Symposium on Document Image Understanding,
     USA, pp. 209-218, 2003),
     an additional constraint is made for the first criterion by demanding
-    that no other segment may be between *a* and *b* that opverlaps
+    that no other segment may be between *a* and *b* that overlaps
     horizontally with both. This constraint for taking multi column
     headings that interrupt columns into account is replaced in this
     implementation with an a priori sort of all textlines by *y*-position.

--- a/gamera/plugins/segmentation.py
+++ b/gamera/plugins/segmentation.py
@@ -95,7 +95,7 @@ class splitx_max(Segmenter):
     the projections near *center*.
 
     This function is overloaded to work both with a single value and a
-    list of splitting point canidates as input.
+    list of splitting point candidates as input.
     """
     args = Args([FloatVector("center", default=[0.5])])
     def __call__(self, center=0.5):
@@ -114,7 +114,7 @@ class splity(Segmenter):
     the projections near *center*.
 
     This function is overloaded to work both with a single value and a
-    list of splitting point canidates as input.
+    list of splitting point candidates as input.
     """
     args = Args([FloatVector("center", default=[0.5])])
     def __call__(self, center=[0.5]):

--- a/gamera/plugins/thinning.py
+++ b/gamera/plugins/thinning.py
@@ -110,7 +110,7 @@ class thin_lc(Thinning):
     the ends of the skeleton will not extend to the edges of the
     original image.
 
-    H.-J. Lee and B. Chen. 1992.  Recognition of handwritten chinese
+    H.-J. Lee and B. Chen. 1992.  Recognition of handwritten Chinese
     characters via short line segments. *Pattern Recognition*. 25(5)
     543-552.
     """

--- a/include/plugins/thinning.hpp
+++ b/include/plugins/thinning.hpp
@@ -316,7 +316,7 @@ namespace Gamera {
   the Xite implementation.
 
   &[1]H.-J. Lee and B. Chen,
-  "Recognition of handwritten chinese characters via short
+  "Recognition of handwritten Chinese characters via short
   line segments,"
   Pattern Recognition,
   vol. 25, no. 5, pp. 543-552, 1992.

--- a/include/region.hpp
+++ b/include/region.hpp
@@ -37,7 +37,7 @@
   (as represented by a rectangle) and some values (represented as a key
   value pair (string/double)). By convention regions should contain a key
   called "scaling" that returns the default value for that region. This is
-  used in feature functions that are dependant on some relative value (i.e.
+  used in feature functions that are dependent on some relative value (i.e.
   the height of glyphs in music recognition is scaled by the size of the 
   staff space + the size of the staff line).
 

--- a/include/rle_data.hpp
+++ b/include/rle_data.hpp
@@ -87,7 +87,7 @@ namespace Gamera {
       increments every time the structure of the run lists changes
       (but not merely the pixel values).  The iterators on the run
       data check their own internal copy of m_dirty against
-      RleVector's everytime a pixel access needs to be made.  If
+      RleVector's every time a pixel access needs to be made.  If
       different, a full search of the run list is performed to find
       the correct current run, and then the iterator's copy of m_dirty
       is updated.  If the same, the iterator's pointer to the current

--- a/include/vigra/fftw3.hxx
+++ b/include/vigra/fftw3.hxx
@@ -1545,7 +1545,7 @@ void applyFourierFilterImplNormalization(FFTWComplexImage const & srcImage,
 
     Filters and result images must be stored in \ref vigra::ImageArray data
     structures. In contrast to \ref applyFourierFilter(), this function adjusts
-    the size of the result images and the the length of the array.
+    the size of the result images and the length of the array.
 
     <b> Declarations:</b>
 

--- a/include/vigra/numerictraits.hxx
+++ b/include/vigra/numerictraits.hxx
@@ -100,10 +100,10 @@
     }
     \endcode 
     
-    The return type of this function can not be 'unsigned char' because
+    The return type of this function cannot be 'unsigned char' because
     the summation would very likely overflow. Since we know the source
     type, we can easily choose 'int' as an appropriate return type.
-    Likewise, we would have choosen 'float' if we had to sum a 
+    Likewise, we would have chosen 'float' if we had to sum a 
     sequence of floats. If we want to make this 
     algorithm generic, we would like to derive the appropriate return 
     type automatically. This can be done with NumericTraits. 

--- a/migration_tools/generate_migration_docs
+++ b/migration_tools/generate_migration_docs
@@ -175,7 +175,7 @@ Python code
 -----------
 
 Finding the deprecated calls in Python code is somewhat more
-difficult, since the exact function calls being made can not be
+difficult, since the exact function calls being made cannot be
 determined until runtime.
 
 When a deprecated function call is made, a deprecation warning is

--- a/src/floatpointobject.cpp
+++ b/src/floatpointobject.cpp
@@ -248,7 +248,7 @@ void init_FloatPointType(PyObject* module_dict) {
 "**FloatPoint** ((*x*, *y*))\n\n"
 "FloatPoint stores an (*x*, *y*) coordinate point using floating-point values.\n"
 "It is an immutable object, i.e., once it has been created at a certain position,\n"
-"it can not be moved.\n\n"
+"it cannot be moved.\n\n"
 "The standard Gamera ``Point`` stores coordinates as unsigned (positive) integers, "
 "and doesn't have any arithmetic operators.  For this reason, ``FloatPoint`` is "
 "highly recommended for any analyses that require precision and flexibility.  ``Point`` "

--- a/src/knngamodule.cpp
+++ b/src/knngamodule.cpp
@@ -496,7 +496,7 @@ void init_GASelectionType(PyObject *d) {
         "The ``GASelection`` constructor creates a new settings object "
         "for the GA-optimization which specifies the used individuals selection method. "
         "This object can later be used in an ``GAOptimization``-object. \n\n"
-        "Only one selection method can be choosen. Multiple settings will "
+        "Only one selection method can be chosen. Multiple settings will "
         "override each other.";
 
     PyType_Ready(&GASelectionType);
@@ -1136,7 +1136,7 @@ void init_GAReplacementType(PyObject *d) {
         "The ``GAReplacement`` constructor creates a new settings object "
         "for the GA-optimization which specifies the used replacement method. "
         "This object can later be used in an ``GAOptimization``-object. \n\n"
-        "Only one replacement method can be choosen. Multiple settings will "
+        "Only one replacement method can be chosen. Multiple settings will "
         "override each other.";
 
     PyType_Ready(&GAReplacementType);


### PR DESCRIPTION
Found using [mwic](http://jwilk.net/software/mwic) and [anorack](https://github.com/jwilk/anorack).