### PR TITLE
Scrollbars now appear in Biollante-view when ExpertSettings are shown

### DIFF
--- a/gamera/gui/gaoptimizer/SettingsPanel.py
+++ b/gamera/gui/gaoptimizer/SettingsPanel.py
@@ -196,7 +196,7 @@ class SettingsPanel(wx.ScrolledWindow):
     def OnPaneChanged(self, event):
     #---------------------------------------------------------------------------
         # redo the layout ... necessary!
-        self.Layout()
+        self.PostSizeEvent()
         
     #---------------------------------------------------------------------------
     def OnOpModeChange(self, event):


### PR DESCRIPTION
Start|Stop now reachable with expanded Expert Settings without resizing the window