### PR TITLE
remove Python 2.2 compat code

### DIFF
--- a/gamera/gamera_xml.py
+++ b/gamera/gamera_xml.py
@@ -133,7 +133,7 @@ class WriteXML:
       if len(glyphs):
          word_wrap(stream, '<glyphs>', indent)
          indent += 1
-         for i, glyph in util.enumerate(glyphs):
+         for i, glyph in enumerate(glyphs):
             self._write_glyph(stream, glyph, indent)
             progress.step()
          indent -= 1

--- a/gamera/pyplate.py
+++ b/gamera/pyplate.py
@@ -211,7 +211,7 @@ class ForTemplateNode(TemplateNode):
             if len(self.vars) == 1:
                data[self.vars[0]] = list
             elif len(self.vars) == len(list):
-               for index, value in util.enumerate(list):
+               for index, value in enumerate(list):
                   data[self.vars[index]] = value
             else:
                self.parent.parser_exception(
@@ -291,7 +291,7 @@ class FunctionTemplateNode(TemplateNode):
 
    def call(self, args, stream, data):
       remember_vars = {}
-      for index, var in util.enumerate(self.vars):
+      for index, var in enumerate(self.vars):
          if data.has_key(var):
             remember_vars[var] = data[var]
          data[var] = args[index]

--- a/gamera/util.py
+++ b/gamera/util.py
@@ -173,20 +173,6 @@ def pretty_print_byte_size(bytes):
          return "%.2f %s" % (float(bytes) / step[1], step[0])
    return 'error (negative!)'
 
-if float(sys.version[0:3]) < 2.3:
-   def enumerate(collection):
-      """Backport to 2.2 of Python 2.3's enumerate function."""
-      i = 0
-      it = iter(collection)
-      while 1:
-         yield(i, it.next())
-         i += 1
-   __builtins__['enumerate'] = enumerate
-   __builtins__['True'] = 1
-   __builtins__['False'] = 0
-else:
-   enumerate = __builtins__['enumerate']
-
 _pixel_type_names = {ONEBIT:     "OneBit",
                      GREYSCALE:  "GreyScale",
                      GREY16:     "Grey16",


### PR DESCRIPTION
Gamera has required at least Python 2.3 for over a decade.