### PR TITLE
Use __builtin__ module instead of __builtins__

### DIFF
--- a/gamera/generate.py
+++ b/gamera/generate.py
@@ -28,6 +28,7 @@ from distutils.core import Extension
 from distutils.dep_util import newer
 from distutils import sysconfig
 from gamera import paths, args_wrappers
+import __builtin__
 
 global std_import
 global plugins_to_ignore
@@ -57,13 +58,13 @@ def magic_import_setup(ignore):
    global std_import
    plugins_to_ignore = ignore
    # Save the standard __import__ function so we can chain to it
-   std_import = __builtins__['__import__']
+   std_import = __builtin__.__import__
    # Override the __import__ function with our new one
-   __builtins__['__import__'] = magic_import
+   __builtin__.__import__ = magic_import
 
 def restore_import():
    global std_import
-   __builtins__['__import__'] = std_import
+   __builtin__.__import__ = std_import
 
 template = Template("""
   [[exec from os import path]]


### PR DESCRIPTION
As per <https://docs.python.org/2/reference/executionmodel.html>:
> Users should not touch `__builtins__`; it is strictly an implementation detail. Users wanting to override values in the builtins namespace should import the `__builtin__` (no ‘s’) module and modify its attributes appropriately.

There's another instance of `__builtins__` in the Gamera codebase, but #21 takes care of removing it.

(I'm trying to port Gamera to PyPy, which has an incompatible `__builtins__`.)